### PR TITLE
Remove assert that dataset-id was present

### DIFF
--- a/src/metabase/driver/bigquery_alt/query_processor.clj
+++ b/src/metabase/driver/bigquery_alt/query_processor.clj
@@ -676,7 +676,6 @@
     :as                                                         outer-query}]
   (let [{dataset-id :schema} (some-> source-table-id qp.store/table)
         {table-name :name} (some-> source-table-id qp.store/table)]
-    (assert (seq dataset-id))
     (binding [sql.qp/*query* (assoc outer-query :dataset-id dataset-id)]
       (let [[sql & params] (->> outer-query
                                 (sql.qp/mbql->honeysql driver)


### PR DESCRIPTION
An assert for the dataset-id was throwing an error when a question was used as the source to a subsequent question. Just removing the assert doesn't seem to have caused any negative affects and allows nested questions.